### PR TITLE
Fix read string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-xp",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "description": "Puppet XP for Wechaty",
   "type": "module",
   "exports": {

--- a/src/init-agent-script.js
+++ b/src/init-agent-script.js
@@ -104,11 +104,11 @@ const getMyselfInfoFunction = (() => {
  let   wx_name      = ''
  let   head_img_url = ''
 
- wx_id   = readStringPtr(moduleBaseAddress.add(offset.wxid_offset)).readUtf8String()
+ wx_id   = readString(moduleBaseAddress.add(offset.wxid_offset))
  wx_code = wx_id
 
- wx_name   = readStringPtr(moduleBaseAddress.add(offset.nickname_offset)).readUtf8String()
- head_img_url   = readStringPtr(moduleBaseAddress.add(offset.head_img_url_offset)).readUtf8String()
+ wx_name   = readString(moduleBaseAddress.add(offset.nickname_offset))
+ head_img_url   = readString(moduleBaseAddress.add(offset.head_img_url_offset))
 
 
  const myself = {
@@ -135,12 +135,12 @@ const chatroomRecurse = ((node)=>{
  }
 
  chatroomNodeList.push(node)
- const roomid = readWStringPtr(node.add(0x10)).readUtf16String()
+ const roomid = readWideString(node.add(0x10))
 
  const len = Memory.readU32(node.add(0x50))   //
  //const memberJson={}
  if(len >4){//
-   const memberStr = readStringPtr(node.add(0x40)).readUtf8String()
+   const memberStr = readString(node.add(0x40))
    if(memberStr.length>0){
        const memberList = memberStr.split(/[\\^][G]/)
        const memberJson ={
@@ -395,14 +395,14 @@ const checkQRLoginNativeCallback =(()=>{
   Interceptor.attach(moduleBaseAddress.add(offset.hook_save_login_qr_info_offset),{
     onEnter: function () {
       const qrNotify = this.context['ebp'].sub(72)
-      const uuid = readStringPtr(qrNotify.add(4).readPointer()).readUtf8String()
-      const wxid = readStringPtr(qrNotify.add(8).readPointer()).readUtf8String()
+      const uuid = readString(qrNotify.add(4).readPointer())
+      const wxid = readString(qrNotify.add(8).readPointer())
       const status = qrNotify.add(16).readUInt()
-      const avatarUrl = readStringPtr(qrNotify.add(24).readPointer()).readUtf8String()
-      const nickname = readStringPtr(qrNotify.add(28).readPointer()).readUtf8String()
-      const pairWaitTip = readStringPtr(qrNotify.add(32).readPointer()).readUtf8String()
+      const avatarUrl = readString(qrNotify.add(24).readPointer())
+      const nickname = readString(qrNotify.add(28).readPointer())
+      const pairWaitTip = readString(qrNotify.add(32).readPointer())
       const phoneClientVer = qrNotify.add(40).readUInt()
-      const phoneType = readStringPtr(qrNotify.add(44).readPointer()).readUtf8String()
+      const phoneType = readString(qrNotify.add(44).readPointer())
 
       const json = {
         status,
@@ -444,10 +444,10 @@ const getQrcodeLoginData = () => {
   }
 
   if (!qlMgr.isNull()) {
-    json.uuid = readStringPtr(qlMgr.add(8)).readUtf8String()
+    json.uuid = readString(qlMgr.add(8))
     json.status = qlMgr.add(40).readUInt()
-    json.wxid = readStringPtr(qlMgr.add(44)).readUtf8String()
-    json.avatarUrl = readStringPtr(qlMgr.add(92)).readUtf8String()
+    json.wxid = readString(qlMgr.add(44))
+    json.avatarUrl = readString(qlMgr.add(92))
   }
   return json
 }
@@ -671,7 +671,7 @@ const getChatroomMemberNickInfoFunction = ( (memberId,roomId) =>{
  const nativeativeFunction = new NativeFunction(ptr(memberNickBuffAsm), 'void', [])
  nativeativeFunction()
 
- return readWStringPtr(nickRetAddr.readPointer()).readUtf16String()
+ return readWideString(nickRetAddr.readPointer())
 
 })
 

--- a/src/init-agent-script.js
+++ b/src/init-agent-script.js
@@ -235,13 +235,7 @@ const recurse = ((node) =>{
   nodeList.push(node)
   const wxid    = readWideString(node.add(0x38))
 
-  const sign    = node.add(0x4c+0x4).readU32()//
-  let wx_code=''
-  if(sign == 0){
-    wx_code = readWideString(node.add(0x38))
-  }else{
-    wx_code = readWideString(node.add(0x4c))
-  }
+  const wx_code = readWideString(node.add(0x4c)) || readWideString(node.add(0x38))
 
 
   const name = readWideString(node.add(0x94))

--- a/src/init-agent-script.js
+++ b/src/init-agent-script.js
@@ -233,18 +233,18 @@ const recurse = ((node) =>{
 
 
   nodeList.push(node)
-  const wxid    = readStringPtr(node.add(0x38)).readUtf8String()
+  const wxid    = readWideString(node.add(0x38))
 
   const sign    = node.add(0x4c+0x4).readU32()//
   let wx_code=''
   if(sign == 0){
-    wx_code = readStringPtr(node.add(0x38)).readUtf8String()
+    wx_code = readWideString(node.add(0x38))
   }else{
-    wx_code = readStringPtr(node.add(0x4c)).readUtf8String()
+    wx_code = readWideString(node.add(0x4c))
   }
 
 
-  const name = readStringPtr(node.add(0x94)).readUtf8String()
+  const name = readWideString(node.add(0x94))
 
   const contactJson={
     id:wxid,

--- a/src/init-agent-script.js
+++ b/src/init-agent-script.js
@@ -186,6 +186,7 @@ const readStringPtr = (address) => {
 
   // console.log('readStringPtr() address:',address,' -> str ptr:', addr.ptr, 'size:', addr.size, 'capacity:', addr.capacity)
   // console.log('readStringPtr() str:' , addr.readUtf8String())
+  // console.log('readStringPtr() address:', addr,'dump:', addr.readByteArray(24))
 
   return addr
 }
@@ -204,8 +205,17 @@ const readWStringPtr = (address) => {
 
   // console.log('readWStringPtr() address:',address,' -> ptr:', addr.ptr, 'size:', addr.size, 'capacity:', addr.capacity)
   // console.log('readWStringPtr() str:' ,  `"${addr.readUtf16String()}"`,'\n',addr.ptr.readByteArray(addr.size*2+2),'\n')
+  // console.log('readWStringPtr() address:', addr,'dump:', addr.readByteArray(16),'\n')
 
   return addr
+}
+
+const readString = (address) => {
+  return readStringPtr(address).readUtf8String()
+}
+
+const readWideString = (address) => {
+  return readWStringPtr(address).readUtf16String()
 }
 
 //contact


### PR DESCRIPTION
The previously added `readStringPtr()` and `readWString()` are easy to be confused. Second, they only have the function of preventing reading of null pointers, which is still not easy to use. 

Therefore, the following modifications have been made:

- add `readString()`: For convenient reading of `utf8` strings
- add `readWideString()`: For convenient reading of `utf16` strings
- fixes read type error. 

Thanks @ericcug : https://github.com/wechaty/puppet-xp/pull/70#issuecomment-1031892650
