### PR TITLE
Fix qrcode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-xp",
-  "version": "1.10.12",
+  "version": "1.10.13",
   "description": "Puppet XP for Wechaty",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-xp",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "description": "Puppet XP for Wechaty",
   "type": "module",
   "exports": {

--- a/src/init-agent-script.js
+++ b/src/init-agent-script.js
@@ -369,7 +369,7 @@ const checkQRLoginNativeCallback =(()=>{
   const ret = (json) => {
      const arr = [
         json.status||0,
-        Memory.allocUtf8String(json.uuid?`https://weixin.qq.com/x/${json.uuid}`:''),
+        Memory.allocUtf8String(json.uuid?`http://weixin.qq.com/x/${json.uuid}`:''),
         Memory.allocUtf8String(json.wxid||''),
         Memory.allocUtf8String(json.avatarUrl||''),
         Memory.allocUtf8String(json.nickname||''),


### PR DESCRIPTION
The QR code generated in WeChat starts with `http` instead of `https`

![image](https://user-images.githubusercontent.com/5285894/152922051-3f59f1d9-183a-42ad-b088-64e9210826a4.png)
