### PR TITLE
收到文件后延迟处理

### DIFF
--- a/src/puppet-xp.ts
+++ b/src/puppet-xp.ts
@@ -811,6 +811,12 @@ class PuppetXp extends PUPPET.Puppet {
         const filePath = `${this.selfInfo.id}\\FileStorage\\File\\${year}-${month}`
         dataPath = rootPath + filePath + fileName  // 要解密的文件路径
         // console.info(dataPath)
+
+        await wait(1500)
+        if (!fs.existsSync(dataPath)) {
+          await wait(1500)
+        }
+        
         return FileBox.fromFile(
           dataPath,
           fileName,


### PR DESCRIPTION
当收到文件消息后，在文件还未下载成功时便调用 `messageFile` 会产生 `no such file or directory` 错误，这种情况基本 100% 出现，因此可以在真正处理前做 1.5s ~ 3s 延迟处理。